### PR TITLE
Upgrade to CakePHP 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 5.5
     - 5.6
     - 7.0
     - 7.1
@@ -26,7 +25,7 @@ matrix:
           dist: trusty
     fast_finish: true
     include:
-        - php: 5.5
+        - php: 5.6
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
         - php: hhvm
           dist: trusty

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "php-http/httplug": "^1.0",
         "php-http/discovery": "^1.0",
         "cakephp/cakephp": "^3.4.12"

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,5 @@
         "branch-alias": {
             "dev-master": "0.1-dev"
         }
-    },
-    "prefer-stable": true,
-    "minimum-stability": "dev"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^5.5 || ^7.0",
         "php-http/httplug": "^1.0",
         "php-http/discovery": "^1.0",
-        "cakephp/cakephp": "^3.4"
+        "cakephp/cakephp": "^3.4.12"
     },
     "require-dev": {
         "php-http/client-integration-tests": "^0.6"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^5.5 || ^7.0",
         "php-http/httplug": "^1.0",
         "php-http/discovery": "^1.0",
-        "cakephp/cakephp": "^3.1"
+        "cakephp/cakephp": "^3.4"
     },
     "require-dev": {
         "php-http/client-integration-tests": "^0.6"

--- a/src/Client.php
+++ b/src/Client.php
@@ -38,7 +38,7 @@ class Client implements HttpClient
     public function sendRequest(RequestInterface $request)
     {
         $cakeRequest = new Request(
-            (string)$request->getUri(),
+            (string) $request->getUri(),
             $request->getMethod(),
             $request->getHeaders()
         );

--- a/src/Client.php
+++ b/src/Client.php
@@ -47,7 +47,7 @@ class Client implements HttpClient
             ->withProtocolVersion($request->getProtocolVersion())
             ->withBody($request->getBody());
 
-        if ($cakeRequest->header('Content-Type') === null) {
+        if (null === $cakeRequest->header('Content-Type')) {
             $cakeRequest->header('Content-Type', 'application/x-www-form-urlencoded');
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,8 +3,8 @@
 namespace Http\Adapter\Cake;
 
 use Cake\Core\Exception\Exception;
-use Cake\Network\Http\Client as CakeClient;
-use Cake\Network\Http\Request;
+use Cake\Http\Client as CakeClient;
+use Cake\Http\Client\Request;
 use Http\Client\Exception\NetworkException;
 use Http\Client\HttpClient;
 use Http\Discovery\MessageFactoryDiscovery;
@@ -12,7 +12,7 @@ use Http\Message\ResponseFactory;
 use Psr\Http\Message\RequestInterface;
 
 /**
- * Client compatible with PSR7 and Httplug interfaces, using a cackephp client.
+ * Client compatible with PSR7 and Httplug interfaces, using a CakePHP client.
  */
 class Client implements HttpClient
 {
@@ -37,32 +37,26 @@ class Client implements HttpClient
      */
     public function sendRequest(RequestInterface $request)
     {
-        $cakeRequest = new Request();
-        $cakeRequest->method($request->getMethod());
-        $cakeRequest->url((string) $request->getUri());
-        $cakeRequest->version($request->getProtocolVersion());
-        $cakeRequest->body($request->getBody()->getContents());
+        $cakeRequest = new Request(
+            (string)$request->getUri(),
+            $request->getMethod(),
+            $request->getHeaders()
+        );
 
-        foreach ($request->getHeaders() as $header => $values) {
-            $cakeRequest->header($header, $request->getHeaderLine($header));
-        }
+        $cakeRequest = $cakeRequest
+            ->withProtocolVersion($request->getProtocolVersion())
+            ->withBody($request->getBody());
 
-        if (null === $cakeRequest->header('Content-Type')) {
+        if ($cakeRequest->header('Content-Type') === null) {
             $cakeRequest->header('Content-Type', 'application/x-www-form-urlencoded');
         }
 
         try {
-            $cakeResponse = $this->client->send($cakeRequest, $this->client->config());
+            $response = $this->client->send($cakeRequest, $this->client->config());
         } catch (Exception $exception) {
             throw new NetworkException('Failed to send request', $request, $exception);
         }
 
-        return $this->responseFactory->createResponse(
-            $cakeResponse->statusCode(),
-            null,
-            $cakeResponse->headers(),
-            $cakeResponse->body(),
-            $cakeResponse->version()
-        );
+        return $response;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | maybe
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT


#### What's in this PR?

CakePHP dependency has been updated to 3.4

#### Why?

CakePHP 3.4 supports PSR7 so lesser code is required by this adapter. Easier maintenance :)

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)
