### PR TITLE
composer.json - use stable CakePHP 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.1",
         "php-http/httplug": "^2.0",
         "php-http/discovery": "^1.0",
-        "cakephp/cakephp": "5.x-dev"
+        "cakephp/cakephp": "^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| Documentation   |
| License         | MIT


#### What's in this PR?

Updated composer.json to use stable CakePHP 5.x by default.


#### Why?

Applications using this plugin cannot use the stable CakePHP 5.x.